### PR TITLE
New path for LibKRW plugins (From /usr/lib/libkrw to /opt/libkrw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Starting with version 1.1.0, libkrw supports a plugin interface so you no longer
 2. Implement and export either a function called `krw_initializer` or `kcall_initializer` that takes a `krw_handlers_t` argument.
 3. Install all handlers that you support.
 4. Compile with `-Wl,-bundle`.
-5. Name it `/usr/lib/libkrw/[name].dylib`.
+5. Name it `/opt/libkrw/[name].dylib`.
 6. Add this to the `control` of your deb file:  
    ```
    Depends: libkrw

--- a/src/libkrw.c
+++ b/src/libkrw.c
@@ -93,10 +93,10 @@ static int obtain_krw_funcs(void *plugin) {
 static void iterate_plugins(int (*callback)(void *), void **check) {
   struct dirent **plugins;
   char *krw_path = NULL;
-  if(access("/usr/lib/libkrw/", F_OK) == 0) {
-    krw_path = "/usr/lib/libkrw/";
+  if(access("/opt/libkrw/", F_OK) == 0) {
+    krw_path = "/opt/libkrw/";
   } else {
-    krw_path = JBROOT_PATH_CSTRING("/usr/lib/libkrw/");
+    krw_path = JBROOT_PATH_CSTRING("/opt/libkrw/");
   }
   libkrw_log(stdout, "[+]: %s: %s: krw_path: %s\n", TARGET, __FUNCTION__, krw_path);
   ssize_t nument = scandir(krw_path, &plugins, &scandir_dylib_select, &scandir_alpha_compar);


### PR DESCRIPTION
Hi !

A tiny change to take care the fact the new practices prefers to use `/opt`instead of `/usr/lib`to store additional program files.
Please tell me if other changes have to be made, because I did not found `/usr/lib`occurrences elsewhere.

Best regards